### PR TITLE
Always return NULL for attributes

### DIFF
--- a/src/User.php
+++ b/src/User.php
@@ -44,7 +44,7 @@ class User
     public function __construct($attributes = [])
     {
         foreach ($attributes as $key => $value) {
-            if (property_exists($this, 'key')) {
+            if (property_exists($this, $key)) {
                 $this->$key = $value;
             }
         }


### PR DESCRIPTION
property_exists($this, 'key') will never be true. Using $key instead.